### PR TITLE
Fix RegisterKernel.cmd and reg.sh

### DIFF
--- a/src/Apps/Kernel/RegisterKernel.cmd
+++ b/src/Apps/Kernel/RegisterKernel.cmd
@@ -7,7 +7,7 @@ if "%BLD%"=="" (
     set BLD=Debug
 )
 
-set EDIR=%~dp0../xout/bin/RexlKernel/x64/%BLD%/net6.0/
+set EDIR=%~dp0../../xout/bin/RexlKernel/x64/%BLD%/net6.0/
 set EDIR=%EDIR:\=/%
 
 echo EDIR: %EDIR%

--- a/src/Apps/Kernel/reg.sh
+++ b/src/Apps/Kernel/reg.sh
@@ -4,7 +4,7 @@ if [[ -z "$BLD" ]]; then
 fi
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1; pwd -P)"
-SRC_DIR="$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1; cd .. >/dev/null 2>&1; pwd -P)"
+SRC_DIR="$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1; cd ../.. >/dev/null 2>&1; pwd -P)"
 # echo "$SRC_DIR"
 
 EDIR="$SRC_DIR/xout/bin/RexlKernel/x64/$BLD/net6.0"


### PR DESCRIPTION
The `RegisterKernel.cmd` and `reg.sh` scripts were authored when `Kernel` was directly under `src` instead of under `src/Apps`. This change fixes them.