### PR TITLE
Added SudokuMipEp sample notebook

### DIFF
--- a/samples/notebooks/SudokuMipEq.ipynb
+++ b/samples/notebooks/SudokuMipEq.ipynb
@@ -1,0 +1,1165 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "550b4bba-c2ef-4055-8a3b-d7b2c1a10f10",
+   "metadata": {},
+   "source": [
+    "# Sudoku Using a MIP Solver\n",
+    "\n",
+    "NOTE: This notebook matches the SudokuMip notebook except that this uses `= 1` in the constraints.\n",
+    "This is a strong formulation which generally helps MIP solvers perform better.\n",
+    "\n",
+    "Solve sudoku puzzles using a MIP (Mixed Integer linear Program) solver. We've integrated three solvers,\n",
+    "HiGHS, Gurobi, and GLPK. Gurobi requires a license to run so is only used in the final solve. If you don't\n",
+    "have a Gurobi license, that run will produce an error."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f342ac80-b455-4c51-909d-5b5008b47637",
+   "metadata": {},
+   "source": [
+    "## Define a function to map a digit character to its value.\n",
+    "\n",
+    "We define a function that maps from a Unicode character to its \"value\" from the\n",
+    "perspective of Sudoku. We want to support traditional Sudoku (of rank 3) as\n",
+    "well as higher ranks, up to rank 6, so we need a total of 36 symbols. Traditional\n",
+    "Sudoku uses `\"123456789\"`. To get 36 symbols, we'll also use `0` and `A`\n",
+    "through `Z`, so our symbols are `\"1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ\"`.\n",
+    "\n",
+    "This function should map a Unicode character to its position in our symbol list,\n",
+    "and return `-1` if the Unicode character is not one of our symbols."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a05b6e99-4d43-447f-95d7-5ecb482cbbd2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "// Accepts a Unicode code point. Returns the index into\n",
+    "// \"1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ\", or -1 if not found.\n",
+    "// Note that 0 follows 9.\n",
+    "\n",
+    "func ToDigit(ch) :=\n",
+    "  ch - \"1\"[0] if \"1\"[0] <= ch <= \"9\"[0]      else\n",
+    "  9           if           ch  = \"0\"[0]      else\n",
+    "  ch - \"A\"[0] + 10 if \"A\"[0] <= ch <= \"Z\"[0] else\n",
+    "  ch - \"A\"[0] + 10 if \"A\"[0] <= ch <= \"Z\"[0] else\n",
+    "  -1;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15559751-117b-4d90-bd6d-ccabf058c305",
+   "metadata": {},
+   "source": [
+    "## Define the module.\n",
+    "\n",
+    "The parameter `M` specifies the grid size value, with default of `3`. This can handle `M` values of `3`, `4`, `5`, and `6`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6d05945d-e67c-4d56-98bd-bde44917adf1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Sudoku := module {\n",
+    "    param M := 3;\n",
+    "    const N := M * M;\n",
+    "    const NumCells := N * N;\n",
+    "    const NumMoves := NumCells * N;\n",
+    "\n",
+    "    // All possible \"moves\" where \"move\" means \"place a value in a cell\".\n",
+    "    const Moves := Range(NumMoves)\n",
+    "        ->ForEach(as Id,\n",
+    "            With(cell: Id div N, row: cell div N, col: cell mod N,\n",
+    "                { Id, XRow: row, XCol: col, YBlk: row div M * M + col div M, ZVal: Id mod N }));\n",
+    "\n",
+    "    // Group the moves in various ways. These are used for constraints below.\n",
+    "    // Each group of these represent, respectively:\n",
+    "    // * The possible values for a particular cell.\n",
+    "    // * The possible placements of a particular value in a particular row.\n",
+    "    // * The possible placements of a particular value in a particular column.\n",
+    "    // * The possible placements of a particular value in a particular block.\n",
+    "    const MovesByRowCol := Moves->GroupBy([key] _:XRow, [key] _:XCol);\n",
+    "    const MovesByValRow := Moves->GroupBy([key] _:ZVal, [key] _:XRow);\n",
+    "    const MovesByValCol := Moves->GroupBy([key] _:ZVal, [key] _:XCol);\n",
+    "    const MovesByValBlk := Moves->GroupBy([key] _:ZVal, [key] _:YBlk);\n",
+    "\n",
+    "    // The fixed moves defined by a particular puzzle.\n",
+    "    // Note that this is a parameter, not constant, so can be set externally via\n",
+    "    // module projection (see below).\n",
+    "    param Fixed :=\n",
+    "        \"    2  7 \" &\n",
+    "        \"    34   \" &\n",
+    "        \"358      \" &\n",
+    "        \"5 48     \" &\n",
+    "        \"   1   89\" &\n",
+    "        \"  2     6\" &\n",
+    "        \"24    7  \" &\n",
+    "        \" 9   52  \" &\n",
+    "        \"    671  \";\n",
+    "\n",
+    "    // Map from the Fixed text value to the required moves.\n",
+    "    const ImposedIds :=\n",
+    "        Range(NumCells)\n",
+    "        ->{ cell: it, value: Fixed[it]->ToDigit() }\n",
+    "        ->TakeIf(0 <= value < N)\n",
+    "        ->Map(N * cell + value);\n",
+    "    const NumImposed := ImposedIds->Count();\n",
+    "    const ImposedFlags := Tensor.From(Range(NumMoves)->(it in ImposedIds));\n",
+    "\n",
+    "    // Define a variable (tensor of bool) for the moves that have been made.\n",
+    "    var Flags from Tensor.Fill(false, NumMoves) def ImposedFlags;\n",
+    "\n",
+    "    // Define a measure for the number of moves made.\n",
+    "    // Need to maximize this without violating constraints.\n",
+    "    msr NumMade := Flags.Values->Sum();\n",
+    "\n",
+    "    // Define the constraints.\n",
+    "\n",
+    "    // Require the imposed moves.\n",
+    "    con NeedImposed := ForEach(id:ImposedIds, Flags[id] = 1);\n",
+    "\n",
+    "    // Require no \"duplicates\". That is, for each MovesByXxxYyy above, there\n",
+    "    // can be at most one move from each group.\n",
+    "    // NOTE: Here we use = 1. The other notebook uses <= 1 allowing it to\"do the best\n",
+    "    // possible\" when there is no complete solution. See below for examples.\n",
+    "    con OnePerRowCol := ForEach(c:MovesByRowCol, Sum(c, Flags[Id]) = 1);\n",
+    "    con OnePerValRow := ForEach(c:MovesByValRow, Sum(c, Flags[Id]) = 1);\n",
+    "    con OnePerValCol := ForEach(c:MovesByValCol, Sum(c, Flags[Id]) = 1);\n",
+    "    con OnePerValBlk := ForEach(c:MovesByValBlk, Sum(c, Flags[Id]) = 1);\n",
+    "\n",
+    "    // The Board is for \"pretty\" display of the result.\n",
+    "    const Symbols := \"_1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ\";\n",
+    "    let Board :=\n",
+    "        Moves\n",
+    "        ->TakeIf(Flags[Id])\n",
+    "        ->SortUp(XRow, XCol)\n",
+    "        ->GroupBy(_:XRow)\n",
+    "        ->ForEach(With(row: it,\n",
+    "            ForEach(c: Range(N), With(i: First(row, XCol = c).ZVal + 1 ?? 0, Symbols[i:*1])))\n",
+    "            ->Text.Concat(\"|\"))\n",
+    "        ->Text.Concat(\"\\n\");\n",
+    "};"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96aee655-94b4-490f-9ce7-64ac243f97b5",
+   "metadata": {},
+   "source": [
+    "Display the initial board with only the `Fixed` cells (required values) filled in."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c3055867-e90f-43a2-8880-15814b765fc3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "_|_|_|_|2|_|_|7|_\n",
+       "_|_|_|_|3|4|_|_|_\n",
+       "3|5|8|_|_|_|_|_|_\n",
+       "5|_|4|8|_|_|_|_|_\n",
+       "_|_|_|1|_|_|_|8|9\n",
+       "_|_|2|_|_|_|_|_|6\n",
+       "2|4|_|_|_|_|7|_|_\n",
+       "_|9|_|_|_|5|2|_|_\n",
+       "_|_|_|_|6|7|1|_|_\r\n",
+       "24\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Sudoku.Board;\n",
+    "Sudoku.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11ed3515-b7b4-4707-a6fb-bea420f512d2",
+   "metadata": {},
+   "source": [
+    "Show the constraint values. If any are `false`, then the `Fixed` cells violate the constraints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "04c0d1e7-f316-4933-90a5-2984ce93c035",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true\r\n",
+       "false\r\n",
+       "false\r\n",
+       "false\r\n",
+       "false\r\n",
+       "24\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Sudoku.NeedImposed->All();\n",
+    "Sudoku.OnePerRowCol->All();\n",
+    "Sudoku.OnePerValRow->All();\n",
+    "Sudoku.OnePerValCol->All();\n",
+    "Sudoku.OnePerValBlk->All();\n",
+    "Sudoku.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a749409d-a765-4ffa-a270-7f88a30ced8f",
+   "metadata": {},
+   "source": [
+    "## Solve It"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "5485089c-df40-4f45-aff1-30c580feb824",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solver: HiGHS\r\n",
+       "4|6|1|5|2|8|9|7|3\n",
+       "7|2|9|6|3|4|8|5|1\n",
+       "3|5|8|7|1|9|6|4|2\n",
+       "5|1|4|8|9|6|3|2|7\n",
+       "6|7|3|1|5|2|4|8|9\n",
+       "9|8|2|4|7|3|5|1|6\n",
+       "2|4|6|9|8|1|7|3|5\n",
+       "1|9|7|3|4|5|2|6|8\n",
+       "8|3|5|2|6|7|1|9|4\r\n",
+       "81\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Wall time: 145.7879ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#!time\n",
+    "Sln := Sudoku->Maximize(NumMade, \"highs\");\n",
+    "Sln.Board;\n",
+    "Sln.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "90e8e6ae-8de8-4c22-af26-5c6d3c316b9e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solver: GLPK\r\n",
+       "4|6|1|5|2|8|9|7|3\n",
+       "7|2|9|6|3|4|8|5|1\n",
+       "3|5|8|7|1|9|6|4|2\n",
+       "5|1|4|8|9|6|3|2|7\n",
+       "6|7|3|1|5|2|4|8|9\n",
+       "9|8|2|4|7|3|5|1|6\n",
+       "2|4|6|9|8|1|7|3|5\n",
+       "1|9|7|3|4|5|2|6|8\n",
+       "8|3|5|2|6|7|1|9|4\r\n",
+       "81\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Wall time: 86.0618ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#!time\n",
+    "Sln2 := Sudoku->Maximize(NumMade, \"glpk\");\n",
+    "Sln2.Board;\n",
+    "Sln2.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "196b811a-6d67-4eab-9b40-d3a8d941648e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Sln.Board = Sln2.Board"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c537afdf-b0af-4a1b-b9cd-fd8efc1e6328",
+   "metadata": {},
+   "source": [
+    "## Partial Solve\n",
+    "\n",
+    "This examples starts with the same required values, but with \"2\" added at the end of the 2nd row,\n",
+    "which is inconsistent with the solution. The result is the board cannot be completely filled in.\n",
+    "According to the solvers, the maximum number of cells that can be filled in is 79, leaving 2 unfilled.\n",
+    "\n",
+    "Note that the two solvers find different configurations that achieve the maximum of 79 cells filled.\n",
+    "\n",
+    "NOTE: the comments above are from the other notebook that use `<= ` in the constraints. This notebook\n",
+    "uses `= 1` (requiring the board to be completely filled), so each solver generates an error and\n",
+    "produces a `null` module as the result of `Maximize`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3fcf7d67-7d00-46a3-8166-bda1a27370ac",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "_|_|_|_|2|_|_|7|_\n",
+       "_|_|_|_|3|4|_|_|2\n",
+       "3|5|8|_|_|_|_|_|_\n",
+       "5|_|4|8|_|_|_|_|_\n",
+       "_|_|_|1|_|_|_|8|9\n",
+       "_|_|2|_|_|_|_|_|6\n",
+       "2|4|_|_|_|_|7|_|_\n",
+       "_|9|_|_|_|5|2|_|_\n",
+       "_|_|_|_|6|7|1|_|_\r\n",
+       "25\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Bad := Sudoku=>{\n",
+    "    Fixed:\n",
+    "        \"    2  7 \" &\n",
+    "        \"    34  2\" &\n",
+    "        \"358      \" &\n",
+    "        \"5 48     \" &\n",
+    "        \"   1   89\" &\n",
+    "        \"  2     6\" &\n",
+    "        \"24    7  \" &\n",
+    "        \" 9   52  \" &\n",
+    "        \"    671  \"\n",
+    "};\n",
+    "\n",
+    "Bad.Board;\n",
+    "Bad.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "7da123b5-d069-464f-ae56-dbd8fc463c13",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solver: HiGHS\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Diagnostics:\n",
+      "  Error: Infeasible: contradictory constraints\n",
+      "  Error: Solving failed!\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<null>\r\n",
+       "<null>\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Wall time: 67.0234ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#!time\n",
+    "Sln := Bad->Maximize(NumMade, \"highs\");\n",
+    "Sln.Board;\n",
+    "Sln.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0c8abfca-e462-4968-9082-ed3af1454a85",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solver: GLPK\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Diagnostics:\n",
+      "  Error: Solving failed!\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<null>\r\n",
+       "<null>\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Wall time: 71.3767ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#!time\n",
+    "Sln2 := Bad->Maximize(NumMade, \"glpk\");\n",
+    "Sln2.Board;\n",
+    "Sln2.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "bd46edb7-7df5-4dd5-804f-62136d11e50e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Sln.Board = Sln2.Board"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31f33281-8761-4f36-a5d3-6211b60841ba",
+   "metadata": {},
+   "source": [
+    "## Hardest Sudoku\n",
+    "\n",
+    "The \"internet\" claims this is the world's most difficult sudoku puzzle, taken from\n",
+    "[here](https://www.kristanix.com/sudokuepic/worlds-hardest-sudoku.php). The author of it,\n",
+    "Finnish mathematician Arto Inkala, calls it AI Escargot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "77c7f9b5-a7cb-4fc6-b08f-f3222f005868",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "23\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Hardest := Sudoku=>{\n",
+    "    Fixed:\n",
+    "        \"1    7 9 \" &\n",
+    "        \" 3  2   8\" &\n",
+    "        \"  96  5  \" &\n",
+    "        \"  53  9  \" &\n",
+    "        \" 1  8   2\" &\n",
+    "        \"6    4   \" &\n",
+    "        \"3      1 \" &\n",
+    "        \" 4      7\" &\n",
+    "        \"  7   3  \"\n",
+    "};\n",
+    "\n",
+    "Hardest.NumImposed;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "f0c0a49b-4270-422b-bf39-db86da523d0f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solver: HiGHS\r\n",
+       "1|6|2|8|5|7|4|9|3\n",
+       "5|3|4|1|2|9|6|7|8\n",
+       "7|8|9|6|4|3|5|2|1\n",
+       "4|7|5|3|1|2|9|8|6\n",
+       "9|1|3|5|8|6|7|4|2\n",
+       "6|2|8|7|9|4|1|3|5\n",
+       "3|5|6|4|7|8|2|1|9\n",
+       "2|4|1|9|3|5|8|6|7\n",
+       "8|9|7|2|6|1|3|5|4\r\n",
+       "81\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Wall time: 361.135ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#!time\n",
+    "Sln := Hardest->Maximize(NumMade, \"highs\");\n",
+    "Sln.Board;\n",
+    "Sln.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "754ef117-eeb6-4a9a-9931-3d22de8a1f83",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solver: GLPK\r\n",
+       "1|6|2|8|5|7|4|9|3\n",
+       "5|3|4|1|2|9|6|7|8\n",
+       "7|8|9|6|4|3|5|2|1\n",
+       "4|7|5|3|1|2|9|8|6\n",
+       "9|1|3|5|8|6|7|4|2\n",
+       "6|2|8|7|9|4|1|3|5\n",
+       "3|5|6|4|7|8|2|1|9\n",
+       "2|4|1|9|3|5|8|6|7\n",
+       "8|9|7|2|6|1|3|5|4\r\n",
+       "81\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Wall time: 108.0457ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#!time\n",
+    "Sln2 := Hardest->Maximize(NumMade, \"glpk\");\n",
+    "Sln2.Board;\n",
+    "Sln2.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "d947366c-e5a1-4270-a5fe-6e1ae6c8b43e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Sln.Board = Sln2.Board"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ffe02c4-8d9c-4d68-a2b3-dfa3ae4386c7",
+   "metadata": {},
+   "source": [
+    "## Another difficult one\n",
+    "\n",
+    "This is another difficult one, also authored by Arto Inkala."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "6ccca163-63c9-49cb-8638-250fa4d8926a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Finnish := Sudoku=>{\n",
+    "    Fixed:\n",
+    "        \"8        \" &\n",
+    "        \"  36     \" &\n",
+    "        \" 7  9 2  \" &\n",
+    "        \" 5   7   \" &\n",
+    "        \"    457  \" &\n",
+    "        \"   1   3 \" &\n",
+    "        \"  1    68\" &\n",
+    "        \"  85   1 \" &\n",
+    "        \" 9    4  \"\n",
+    "};"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "7cd351e8-5685-437d-8513-2c5607979e3e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solver: HiGHS\r\n",
+       "8|1|2|7|5|3|6|4|9\n",
+       "9|4|3|6|8|2|1|7|5\n",
+       "6|7|5|4|9|1|2|8|3\n",
+       "1|5|4|2|3|7|8|9|6\n",
+       "3|6|9|8|4|5|7|2|1\n",
+       "2|8|7|1|6|9|5|3|4\n",
+       "5|2|1|9|7|4|3|6|8\n",
+       "4|3|8|5|2|6|9|1|7\n",
+       "7|9|6|3|1|8|4|5|2\r\n",
+       "81\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Wall time: 97.6248ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#!time\n",
+    "Sln := Finnish->Maximize(NumMade, \"highs\");\n",
+    "Sln.Board;\n",
+    "Sln.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "4f64efe7-81c3-456f-a054-a9f30c22304e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solver: GLPK\r\n",
+       "8|1|2|7|5|3|6|4|9\n",
+       "9|4|3|6|8|2|1|7|5\n",
+       "6|7|5|4|9|1|2|8|3\n",
+       "1|5|4|2|3|7|8|9|6\n",
+       "3|6|9|8|4|5|7|2|1\n",
+       "2|8|7|1|6|9|5|3|4\n",
+       "5|2|1|9|7|4|3|6|8\n",
+       "4|3|8|5|2|6|9|1|7\n",
+       "7|9|6|3|1|8|4|5|2\r\n",
+       "81\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Wall time: 89.7634ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#!time\n",
+    "Sln2 := Finnish->Maximize(NumMade, \"glpk\");\n",
+    "Sln2.Board;\n",
+    "Sln2.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "66eee6bb-7620-45d2-a7eb-be9b029a27d1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Sln.Board = Sln2.Board"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "814ad7ca-6c17-4bf6-bd43-710df4184a60",
+   "metadata": {},
+   "source": [
+    "## Generate a Sudoku board from scratch\n",
+    "\n",
+    "Here we specify only the first row. The solution isn't unique and indeed the two solvers produce different results. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "a831e116-7e85-4037-8249-bd4090a721cc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solver: HiGHS\r\n",
+       "1|2|3|4|5|6|7|8|9\n",
+       "5|8|9|2|7|1|6|4|3\n",
+       "4|6|7|9|3|8|5|1|2\n",
+       "9|3|6|7|4|5|1|2|8\n",
+       "2|7|1|3|8|9|4|5|6\n",
+       "8|5|4|6|1|2|9|3|7\n",
+       "3|1|5|8|6|7|2|9|4\n",
+       "6|4|2|5|9|3|8|7|1\n",
+       "7|9|8|1|2|4|3|6|5\r\n",
+       "81\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Wall time: 567.4761ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#!time\n",
+    "Sln := Sudoku=>{ Fixed: \"123456789\" }->Maximize(NumMade, \"highs\");\n",
+    "Sln.Board;\n",
+    "Sln.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "a9eb2b3d-8972-4f11-97fe-f52e01407695",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solver: GLPK\r\n",
+       "1|2|3|4|5|6|7|8|9\n",
+       "4|5|9|7|2|8|6|3|1\n",
+       "8|7|6|3|9|1|2|4|5\n",
+       "2|1|4|8|6|7|9|5|3\n",
+       "3|9|5|1|4|2|8|6|7\n",
+       "7|6|8|9|3|5|1|2|4\n",
+       "6|3|2|5|1|9|4|7|8\n",
+       "9|4|7|2|8|3|5|1|6\n",
+       "5|8|1|6|7|4|3|9|2\r\n",
+       "81\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Wall time: 152.6284ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#!time\n",
+    "Sln2 := Sudoku=>{ Fixed: \"123456789\" }->Maximize(NumMade, \"glpk\");\n",
+    "Sln2.Board;\n",
+    "Sln2.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "8b39ea3a-931a-43a3-9bb6-972021b994cf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "false\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Sln.Board = Sln2.Board;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29604af7-da9e-4788-8a3f-a7f40308f683",
+   "metadata": {},
+   "source": [
+    "## Produce a rank 4 Sudoku board"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c874357-772b-4c6f-bca2-737d824e15bf",
+   "metadata": {},
+   "source": [
+    "Generate a board (specifying the first row) of rank 4.\n",
+    "\n",
+    "NOTE: HiGHS does better with the `= 1` constraints but GLPK does significantly worse.\n",
+    "Compare the times here with the corresponding times in the other notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "29c70854-5442-40aa-a183-fe37c0231775",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solver: HiGHS\r\n",
+       "1|2|3|4|5|6|7|8|9|0|A|B|C|D|E|F\n",
+       "F|E|8|0|D|C|1|B|3|7|2|6|5|A|9|4\n",
+       "D|C|7|B|F|3|A|9|E|8|5|4|0|2|6|1\n",
+       "A|9|6|5|2|E|4|0|F|D|1|C|7|B|8|3\n",
+       "7|F|D|A|1|B|5|E|C|9|0|8|6|4|3|2\n",
+       "E|3|C|9|A|8|F|D|7|6|4|2|B|0|1|5\n",
+       "2|B|0|6|C|9|3|4|D|5|F|1|E|8|A|7\n",
+       "8|4|5|1|6|2|0|7|B|E|3|A|F|C|D|9\n",
+       "6|D|F|E|B|A|C|5|0|4|9|7|3|1|2|8\n",
+       "C|A|B|8|E|7|D|F|1|2|6|3|9|5|4|0\n",
+       "0|7|9|3|8|4|2|1|A|F|E|5|D|6|B|C\n",
+       "5|1|4|2|9|0|6|3|8|C|B|D|A|F|7|E\n",
+       "4|6|E|7|0|F|B|C|2|A|8|9|1|3|5|D\n",
+       "B|0|A|F|7|1|8|2|5|3|D|E|4|9|C|6\n",
+       "9|8|1|D|3|5|E|6|4|B|C|F|2|7|0|A\n",
+       "3|5|2|C|4|D|9|A|6|1|7|0|8|E|F|B\r\n",
+       "256\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Wall time: 10252.2966ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#!time\n",
+    "Sln := Sudoku=>{ Fixed: \"1234567890ABCDEF\", M: 4 }->Maximize(NumMade, \"highs\");\n",
+    "Sln.Board;\n",
+    "Sln.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "7478c473-1b8e-4770-8dcd-f3d8e317b8b1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solver: GLPK\r\n",
+       "1|2|3|4|5|6|7|8|9|0|A|B|C|D|E|F\n",
+       "C|9|7|0|2|A|4|F|D|5|6|E|8|3|B|1\n",
+       "B|6|5|8|3|9|D|E|F|C|1|2|4|A|7|0\n",
+       "F|E|D|A|B|1|C|0|8|7|4|3|9|2|6|5\n",
+       "3|8|1|D|4|C|9|7|6|2|E|A|5|0|F|B\n",
+       "5|A|F|B|1|E|6|2|3|9|0|C|D|8|4|7\n",
+       "6|C|0|2|A|5|8|D|7|F|B|4|3|9|1|E\n",
+       "4|7|9|E|F|0|3|B|5|1|8|D|2|6|C|A\n",
+       "A|5|6|F|9|4|0|1|C|B|D|8|E|7|2|3\n",
+       "0|4|8|9|7|2|B|C|E|3|5|F|6|1|A|D\n",
+       "2|1|C|3|D|8|E|A|0|6|7|9|B|F|5|4\n",
+       "D|B|E|7|6|F|5|3|4|A|2|1|0|C|9|8\n",
+       "7|F|4|C|E|D|2|5|A|8|3|6|1|B|0|9\n",
+       "E|0|B|1|C|3|F|4|2|D|9|7|A|5|8|6\n",
+       "9|D|2|5|8|B|A|6|1|4|F|0|7|E|3|C\n",
+       "8|3|A|6|0|7|1|9|B|E|C|5|F|4|D|2\r\n",
+       "256\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Wall time: 11870.7776ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#!time\n",
+    "Sln2 := Sudoku=>{ Fixed: \"1234567890ABCDEF\", M: 4 }->Maximize(NumMade, \"glpk\");\n",
+    "Sln2.Board;\n",
+    "Sln2.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "9e974f69-6677-4068-9b3b-4b7164350fe2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "false\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Sln.Board = Sln2.Board;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "357b111f-6736-43da-b64a-2f00d28b5e2c",
+   "metadata": {},
+   "source": [
+    "## Produce a rank 5 Sudoku board"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09b2ffa7-ea98-49d3-b7e3-ea17c5fe0402",
+   "metadata": {},
+   "source": [
+    "Now try rank 5, with Gurobi. HiGHS and GLPK don't do well on this one.\n",
+    "Gurobi even struggles with it. Note that this is severely under constrained."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "c9a011e8-4eb4-417d-9fe8-d3cd65f44911",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Solver: Gurobi\r\n",
+       "1|2|3|4|5|6|7|8|9|0|A|B|C|D|E|F|G|H|I|J|K|L|M|N|O\n",
+       "K|C|7|B|M|N|4|A|G|L|H|J|F|0|5|6|O|9|D|1|3|8|2|E|I\n",
+       "6|H|0|I|N|E|5|O|D|M|9|K|G|L|1|3|4|C|8|2|B|A|7|F|J\n",
+       "G|A|D|J|O|I|3|F|K|B|2|7|8|4|N|E|5|0|L|M|9|H|6|C|1\n",
+       "L|8|F|E|9|C|J|2|H|1|O|I|3|M|6|N|B|K|A|7|D|G|5|4|0\n",
+       "J|O|M|2|3|D|0|7|5|N|4|6|L|F|K|H|C|B|E|G|1|I|8|A|9\n",
+       "N|6|4|7|F|M|2|B|E|K|0|D|O|H|G|8|I|A|1|9|L|J|C|5|3\n",
+       "9|5|K|A|H|J|O|G|I|3|1|E|N|C|8|M|L|F|6|D|4|B|0|2|7\n",
+       "E|I|1|G|D|9|A|L|C|8|3|5|M|B|J|2|0|O|7|4|6|K|F|H|N\n",
+       "0|L|B|C|8|H|6|1|F|4|I|A|2|9|7|J|N|5|3|K|G|M|E|O|D\n",
+       "4|E|G|K|J|F|H|9|N|7|D|3|A|5|I|0|8|L|M|C|O|2|1|B|6\n",
+       "C|9|H|8|I|K|G|M|O|E|L|1|0|2|F|B|6|N|J|5|A|D|3|7|4\n",
+       "O|1|5|M|A|2|B|3|4|D|G|N|6|8|C|9|E|7|K|I|J|F|H|0|L\n",
+       "3|D|2|L|6|0|8|C|J|5|7|O|9|K|B|1|H|4|F|A|E|N|G|I|M\n",
+       "F|7|N|0|B|A|L|I|1|6|J|M|4|E|H|O|D|G|2|3|C|9|K|8|5\n",
+       "I|4|A|5|K|8|M|N|0|C|E|H|J|G|D|L|1|2|9|F|7|3|O|6|B\n",
+       "D|N|J|3|C|7|I|K|2|G|6|F|B|A|L|5|M|E|0|O|8|1|4|9|H\n",
+       "2|B|6|O|E|5|9|4|L|J|M|0|1|7|3|D|K|8|H|N|F|C|I|G|A\n",
+       "M|0|8|F|7|3|1|H|B|A|5|4|K|O|9|C|J|I|G|6|N|E|D|L|2\n",
+       "H|G|9|1|L|O|E|D|6|F|8|C|I|N|2|A|7|3|4|B|5|0|J|M|K\n",
+       "8|K|O|H|2|B|D|E|A|I|N|G|5|3|4|7|9|J|C|0|M|6|L|1|F\n",
+       "5|F|C|9|0|L|N|J|3|H|B|8|D|6|M|4|2|1|O|E|I|7|A|K|G\n",
+       "A|J|E|N|G|1|C|0|M|9|F|L|7|I|O|K|3|6|5|H|2|4|B|D|8\n",
+       "B|3|L|D|4|G|F|6|7|O|K|2|E|1|0|I|A|M|N|8|H|5|9|J|C\n",
+       "7|M|I|6|1|4|K|5|8|2|C|9|H|J|A|G|F|D|B|L|0|O|N|3|E\r\n",
+       "625\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Wall time: 29529.878ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#!time\n",
+    "Sln := Sudoku=>{ Fixed: \"1234567890ABCDEFGHIJKLMNO\", M: 5 }->Maximize(NumMade, \"gurobi\");\n",
+    "Sln.Board;\n",
+    "Sln.NumMade;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03f9d89b-fb4e-4474-b858-f156e47e8fe6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Rexl",
+   "language": "Rexl",
+   "name": "rexl"
+  },
+  "language_info": {
+   "file_extension": ".rexl",
+   "mimetype": "text/x-rexl",
+   "name": "Rexl",
+   "pygments_lexer": "rexl",
+   "version": "0.22"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Added a version of the SudokuMip notebook that uses `= 1` in the constraints instead of `<= 1`. This is for comparison of performance as well as behavior (when there is no complete solution).