### PR TITLE
Make the Jupyter kernel handle its registration

### DIFF
--- a/samples/notebooks/Comma.ipynb
+++ b/samples/notebooks/Comma.ipynb
@@ -531,7 +531,7 @@
    "mimetype": "text/x-rexl",
    "name": "Rexl",
    "pygments_lexer": "rexl",
-   "version": "0.22"
+   "version": "1.0"
   }
  },
  "nbformat": 4,

--- a/samples/notebooks/EssentialMedicines.ipynb
+++ b/samples/notebooks/EssentialMedicines.ipynb
@@ -958,7 +958,7 @@
    "mimetype": "text/x-rexl",
    "name": "Rexl",
    "pygments_lexer": "rexl",
-   "version": "0.22"
+   "version": "1.0"
   }
  },
  "nbformat": 4,

--- a/samples/notebooks/ImageAsTensor.ipynb
+++ b/samples/notebooks/ImageAsTensor.ipynb
@@ -431,7 +431,7 @@
    "mimetype": "text/x-rexl",
    "name": "Rexl",
    "pygments_lexer": "rexl",
-   "version": "0.22"
+   "version": "1.0"
   }
  },
  "nbformat": 4,

--- a/samples/notebooks/ImageClassification.ipynb
+++ b/samples/notebooks/ImageClassification.ipynb
@@ -977,7 +977,7 @@
    "mimetype": "text/x-rexl",
    "name": "Rexl",
    "pygments_lexer": "rexl",
-   "version": "0.22"
+   "version": "1.0"
   }
  },
  "nbformat": 4,

--- a/samples/notebooks/NFL.ipynb
+++ b/samples/notebooks/NFL.ipynb
@@ -1313,7 +1313,7 @@
    "mimetype": "text/x-rexl",
    "name": "Rexl",
    "pygments_lexer": "rexl",
-   "version": "0.22"
+   "version": "1.0"
   }
  },
  "nbformat": 4,

--- a/samples/notebooks/SudokuMip.ipynb
+++ b/samples/notebooks/SudokuMip.ipynb
@@ -1127,7 +1127,7 @@
    "mimetype": "text/x-rexl",
    "name": "Rexl",
    "pygments_lexer": "rexl",
-   "version": "0.22"
+   "version": "1.0"
   }
  },
  "nbformat": 4,

--- a/samples/notebooks/SudokuMipEq.ipynb
+++ b/samples/notebooks/SudokuMipEq.ipynb
@@ -1157,7 +1157,7 @@
    "mimetype": "text/x-rexl",
    "name": "Rexl",
    "pygments_lexer": "rexl",
-   "version": "0.22"
+   "version": "1.0"
   }
  },
  "nbformat": 4,

--- a/samples/notebooks/SudokuSat.ipynb
+++ b/samples/notebooks/SudokuSat.ipynb
@@ -1119,7 +1119,7 @@
    "mimetype": "text/x-rexl",
    "name": "Rexl",
    "pygments_lexer": "rexl",
-   "version": "0.22"
+   "version": "1.0"
   }
  },
  "nbformat": 4,

--- a/src/Apps/Kernel/RegisterKernel.cmd
+++ b/src/Apps/Kernel/RegisterKernel.cmd
@@ -10,26 +10,11 @@ if "%BLD%"=="" (
 set EDIR=%~dp0../../xout/bin/RexlKernel/x64/%BLD%/net6.0/
 set EDIR=%EDIR:\=/%
 
-echo EDIR: %EDIR%
-
 if not exist "%EDIR%" (
     echo ERROR: Bld directory '%EDIR%' does not exist
     exit /b 1
 )
 
-set DDIR=.krn-spec-%BLD%
-set DST=%DDIR%\kernel.json
-
-md %DDIR%
-
-echo { > %DST%
-echo     "argv": ["%EDIR%Microsoft.RexlKernel.exe", "{connection_file}"], >> %DST%
-echo     "display_name": "Rexl", >> %DST%
-echo     "language": "Rexl" >> %DST%
-echo } >> %DST%
-
 @echo on
 
-jupyter kernelspec install %DDIR% --name=rexl
-
-jupyter kernelspec list --json
+%EDIR%/Microsoft.RexlKernel register

--- a/src/Apps/Kernel/RexlKernel.Base/Communication/Message.cs
+++ b/src/Apps/Kernel/RexlKernel.Base/Communication/Message.cs
@@ -273,6 +273,17 @@ public sealed class KernelInfoRequest : RequestContent
 }
 
 /// <summary>
+/// Used in <see cref="KernelInfoReply"/>.
+/// </summary>
+public class WebLink
+{
+    [JsonPropertyName("text")]
+    public string Text { get; set; }
+    [JsonPropertyName("url")]
+    public string Url { get; set; }
+}
+
+/// <summary>
 /// Content for a kernel information reply.
 /// </summary>
 public class KernelInfoReply : ReplyContent
@@ -300,11 +311,11 @@ public class KernelInfoReply : ReplyContent
     public bool Debugger { get; }
 
     [JsonPropertyName("help_links")]
-    public IReadOnlyList<Link> HelpLinks { get; }
+    public IReadOnlyList<WebLink> HelpLinks { get; }
 
     public KernelInfoReply(
         string protocolVersion, string implementation, string implementationVersion, LanguageInfo languageInfo,
-        string banner = null, IReadOnlyList<Link> helpLinks = null)
+        string banner = null, IReadOnlyList<WebLink> helpLinks = null)
     {
         Validation.BugCheckNonEmpty(protocolVersion, nameof(protocolVersion));
         Validation.BugCheckNonEmpty(implementation, nameof(implementation));
@@ -317,7 +328,7 @@ public class KernelInfoReply : ReplyContent
         LanguageInfo = languageInfo;
         Banner = banner;
         Debugger = false;
-        HelpLinks = helpLinks ?? new List<Link>();
+        HelpLinks = helpLinks ?? new List<WebLink>();
     }
 
     public override string GetKind() => Names.KernInfoReply;

--- a/src/Apps/Kernel/RexlKernel.Base/Program.cs
+++ b/src/Apps/Kernel/RexlKernel.Base/Program.cs
@@ -40,7 +40,7 @@ public abstract partial class Program : ChannelHost
     public sealed override Logger Logger => _logger;
     public sealed override SignatureHandler Sig => _sig;
 
-    protected Program(string[] args, LogLevel lvl = LogLevel.All)
+    protected Program(ReadOnlySpan<string> args, LogLevel lvl = LogLevel.All)
         : base()
     {
         _session = Guid.NewGuid().ToString();
@@ -88,7 +88,7 @@ public abstract partial class Program : ChannelHost
         _worker = Task.Run(HandleExecuteRequests);
     }
 
-    private void LogArgs(string[] args)
+    private void LogArgs(ReadOnlySpan<string> args)
     {
         _logger.LogLow("Command line args ({0}):", args.Length);
         for (int i = 0; i < args.Length; i++)

--- a/src/Apps/Kernel/RexlKernel/Main.cs
+++ b/src/Apps/Kernel/RexlKernel/Main.cs
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.IO;
 
 namespace Microsoft.Rexl.Kernel;
 
@@ -12,13 +13,44 @@ public sealed partial class RexlProgram : Program
     private readonly Handler.Simple _rexl;
     private readonly Handler.Simple _pfx;
 
+    // The default kernel/language.
+    private readonly string _kernDef;
+
     public override string User => "rexl_user";
 
     public static void Main(string[] args)
     {
         try
         {
-            var prog = new RexlProgram(args);
+            if (args.Length == 0)
+            {
+                PrintUsage();
+                return;
+            }
+
+            var cmd = args[0].ToLowerInvariant();
+            string kernDef;
+            switch (cmd)
+            {
+            default:
+                PrintUsage();
+                return;
+
+            case "pre-register":
+                Register(full: false);
+                return;
+            case "register":
+                Register(full: true);
+                return;
+            case "rexl":
+            case "pfx":
+                if (args.Length <= 1)
+                    goto default;
+                kernDef = cmd;
+                break;
+            }
+
+            var prog = new RexlProgram(kernDef, args.AsSpan(1));
             prog._logger.LogTop("Finished ctor");
             prog.Run();
         }
@@ -28,24 +60,111 @@ public sealed partial class RexlProgram : Program
         }
     }
 
-    private RexlProgram(string[] args, LogLevel lvl = LogLevel.All)
+    private static void PrintUsage()
+    {
+        Console.WriteLine($@"Usage:
+
+    {Path.GetFileNameWithoutExtension(typeof(RexlProgram).Assembly.Location)} <cmd>
+
+    where <cmd> is one of:
+        help: Display this usage information.
+        pre-register: Create the kernel spec directories (.krn-rexl and .krn-pfx).
+        register: Register this with Jupyter.
+        [rexl|pfx] <connection-file>: typically invoked by Jupyter, not directly.
+");
+    }
+
+    private static void Register(bool full)
+    {
+        var loc = typeof(RexlProgram).Assembly.Location;
+        var dirBase = Path.GetDirectoryName(loc);
+        var app = Path.Combine(dirBase, Path.GetFileNameWithoutExtension(loc));
+
+        foreach (var (lang, disp) in new[] { ("Rexl", "Rexl"), ("Pfx", "Power Fx") })
+        {
+            var name = lang.ToLowerInvariant();
+            var dir = Path.Combine(dirBase, $".krn-{name}");
+            Directory.CreateDirectory(dir);
+
+            var path = Path.Combine(dir, "kernel.json");
+            File.WriteAllText(path, $@"{{
+    ""argv"": [""{app.Replace('\\', '/')}"", ""{name}"", ""{{connection_file}}""],
+    ""display_name"": ""{disp}"",
+    ""language"": ""{lang}""
+}}
+");
+
+            if (!full)
+                continue;
+
+            var proc = new System.Diagnostics.Process()
+            {
+                StartInfo =
+                {
+                    FileName = "jupyter",
+                    Arguments = $"kernelspec install \"{dir.Replace('\\', '/')}\" --user --name={name}",
+                    RedirectStandardError = false,
+                    RedirectStandardOutput = false,
+                    RedirectStandardInput = false,
+                }
+            };
+
+            proc.Start();
+            proc.WaitForExit();
+        }
+    }
+
+    private RexlProgram(string kernDef, ReadOnlySpan<string> args, LogLevel lvl = LogLevel.All)
         : base(args, lvl)
     {
-        // REVIEW: Set the default via command line.
         _rexl = new RexlHandler(_logger, _publisher);
-        _handler = new Handler.Composite(_logger, _rexl);
+        _pfx = new PfxHandler(_logger, _publisher);
+
+        switch (kernDef)
+        {
+        case "pfx":
+            _handler = new Handler.Composite(_logger, _pfx);
+            _handler.SetHandler(_rexl);
+            _kernDef = kernDef;
+            break;
+
+        default:
+            _handler = new Handler.Composite(_logger, _rexl);
+            _handler.SetHandler(_pfx);
+            _kernDef = "rexl";
+            break;
+        }
+
+        // Add magics.
         _handler.AddCmd(new LsMagicCmd(_handler));
         _handler.AddCmd(new TimeCmd(_handler));
-
-        _pfx = new PfxHandler(_logger, _publisher);
-        _handler.SetHandler(_pfx);
     }
 
     protected override KernelInfoReply GetKernelInfo()
     {
-        // REVIEW: Fix this.
-        var lang = new LanguageInfo("Rexl", "0.22", "text/x-rexl", ".rexl", "rexl");
-        return new KernelInfoReply(Common.JupyterWireVersion, "irexl", "0.1", lang, "rexl");
+        LanguageInfo lang;
+        string banner;
+        switch (_kernDef)
+        {
+        case "pfx":
+            lang = new LanguageInfo("PowerFx", "1.1", "text/x-pfx", ".pfx", "pfx");
+            banner = "PowerFx";
+            break;
+        default:
+            lang = new LanguageInfo("Rexl", "1.0", "text/x-rexl", ".rexl", "rexl");
+            banner = "Rexl";
+            break;
+        }
+
+        // REVIEW: Current Jupyter seems unable to connect to these links. It shows an error like
+        // "github.com refused to connect".
+        List<WebLink> links = new List<WebLink>() {
+            new WebLink { Text="Rexl Project", Url="https://github.com/microsoft/Rexl" },
+            new WebLink { Text="Rexl User Guide", Url="https://github.com/microsoft/Rexl/blob/main/docs/UserGuide/RexlUserGuide.md" },
+            new WebLink { Text="Power Fx Project", Url="https://github.com/microsoft/Power-Fx" },
+            new WebLink { Text="Power Fx Reference", Url="https://learn.microsoft.com/en-us/power-platform/power-fx/overview" },
+        };
+        return new KernelInfoReply(Common.JupyterWireVersion, "RexlKern", "1.0", lang, banner, links);
     }
 
     protected override Handler GetHandler()

--- a/src/Apps/Kernel/reg.sh
+++ b/src/Apps/Kernel/reg.sh
@@ -15,22 +15,4 @@ if [ ! -d "$EDIR" ]; then
     exit 1
 fi
 
-DDIR="$SCRIPT_DIR/.krn-spec-$BLD"
-# echo "DDIR: $DDIR"
-
-DST="$DDIR/kernel.json"
-# echo "DST: $DST"
-
-mkdir "$DDIR" -p
-
-echo { > "$DST"
-echo     \"argv\": [\"$EDIR/Microsoft.RexlKernel\", \"{connection_file}\"], >> "$DST"
-echo     \"display_name\": \"Rexl\", >> "$DST"
-echo     \"language\": \"Rexl\" >> "$DST"
-echo } >> "$DST"
-
-# cat "$DST"
-
-jupyter kernelspec install --user "$DDIR" --name=rexl
-
-jupyter kernelspec list --json
+"$EDIR/Microsoft.RexlKernel" register

--- a/src/Core/Rexl.Solve/Functions/SatFunctions.cs
+++ b/src/Core/Rexl.Solve/Functions/SatFunctions.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-using Microsoft.Rexl;
 using Microsoft.Rexl.Bind;
 using Microsoft.Rexl.Code;
 using Microsoft.Rexl.Private;
@@ -263,12 +262,13 @@ public sealed partial class SatNotFunc : RexlOper
             Validation.AssertValue(codeGen);
             Validation.Assert(IsValidCall(call, true));
             Validation.Assert(sts.Length == call.Args.Length);
+            Validation.Assert(sts[0] == typeof(long));
 
             codeGen.Writer
                 .Ldc_I8(1)
                 .Xor();
 
-            stRet = typeof(int);
+            stRet = typeof(long);
             return true;
         }
     }

--- a/src/Core/Rexl.Solve/Rexl.Solve.csproj
+++ b/src/Core/Rexl.Solve/Rexl.Solve.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Glpk.Native" />
     <PackageReference Include="Gurobi.Optimizer" />
-    <PackageReference Include="Highs" />
+    <PackageReference Include="Highs.Native" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageVersion Include="Glpk.Native" Version="1.0.2" />
     <PackageVersion Include="Gurobi.Optimizer" Version="10.0.3" />
-    <PackageVersion Include="Highs" Version="1.7.0.7" />
+    <PackageVersion Include="Highs.Native" Version="1.7.0" />
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
     <PackageVersion Include="NetMQ" Version="4.0.1.13" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.16.1" />


### PR DESCRIPTION
This change makes the Jupyter kernel, `Microsoft.RexlKernel`, capable of registering itself for both Rexl and Power Fx.
This also fixes an issue in the code gen for `Sat.Not`.