### PR TITLE
Fix ResizePixels when no change

### DIFF
--- a/src/Core/Rexl.Code/Tensor/Tensor.Transform.cs
+++ b/src/Core/Rexl.Code/Tensor/Tensor.Transform.cs
@@ -448,20 +448,26 @@ partial class Tensor
         {
             // Isotropic with min dimension dy.
             int dsNew = (int)dy;
-            int ds = Math.Min(dySrc, dxSrc);
-            if (ds != dsNew)
+            if (dySrc < dxSrc)
             {
-                long dyNew = ((long)dySrc * dsNew + (ds >> 1)) / ds;
-                long dxNew = ((long)dxSrc * dsNew + (ds >> 1)) / ds;
-                Validation.Assert(dyNew == dsNew | dxNew == dsNew);
-                Validation.Assert(dyNew >= dsNew & dxNew >= dsNew);
-                if (dyNew > int.MaxValue)
-                    return false;
+                long dxNew = ((long)dxSrc * dsNew + (dySrc >> 1)) / dySrc;
+                Validation.Assert(dxNew >= dsNew);
                 if (dxNew > int.MaxValue)
                     return false;
-                dy = (int)dyNew;
+                dy = (int)dsNew;
                 dx = (int)dxNew;
             }
+            else if (dySrc > dxSrc)
+            {
+                long dyNew = ((long)dySrc * dsNew + (dxSrc >> 1)) / dxSrc;
+                Validation.Assert(dyNew >= dsNew);
+                if (dyNew > int.MaxValue)
+                    return false;
+                dy = (int)dyNew;
+                dx = (int)dsNew;
+            }
+            else
+                dy = dx = dsNew;
         }
         return true;
     }

--- a/src/Core/Rexl.Code/Tensor/Tensor.Transform.cs
+++ b/src/Core/Rexl.Code/Tensor/Tensor.Transform.cs
@@ -443,32 +443,59 @@ partial class Tensor
         if (dx != (int)dx)
             return false;
 
-        // If dx <= 0, we're doing isotropic scaling with the min dimension being dy.
-        if (dx <= 0)
+        if (dx > 0)
+            return true;
+
+        // We're doing isotropic scaling with the new min dimension given in dy.
+        int minNew = (int)dy;
+
+        if (dySrc == dxSrc)
         {
-            // Isotropic with min dimension dy.
-            int dsNew = (int)dy;
-            if (dySrc < dxSrc)
-            {
-                long dxNew = ((long)dxSrc * dsNew + (dySrc >> 1)) / dySrc;
-                Validation.Assert(dxNew >= dsNew);
-                if (dxNew > int.MaxValue)
-                    return false;
-                dy = (int)dsNew;
-                dx = (int)dxNew;
-            }
-            else if (dySrc > dxSrc)
-            {
-                long dyNew = ((long)dySrc * dsNew + (dxSrc >> 1)) / dxSrc;
-                Validation.Assert(dyNew >= dsNew);
-                if (dyNew > int.MaxValue)
-                    return false;
-                dy = (int)dyNew;
-                dx = (int)dsNew;
-            }
-            else
-                dy = dx = dsNew;
+            // Square.
+            dy = minNew;
+            dx = minNew;
+            return true;
         }
+
+        if (dySrc < dxSrc)
+        {
+            if (dySrc == minNew)
+            {
+                // No change.
+                dy = dySrc;
+                dx = dxSrc;
+                return true;
+            }
+
+            // Compute the new width.
+            long dxNew = ((long)dxSrc * minNew + (dySrc >> 1)) / dySrc;
+            Validation.Assert(dxNew >= minNew);
+            if (dxNew > int.MaxValue)
+                return false;
+            dy = minNew;
+            dx = (int)dxNew;
+        }
+        else
+        {
+            Validation.Assert(dySrc > dxSrc);
+
+            if (dxSrc == minNew)
+            {
+                // No change.
+                dy = dySrc;
+                dx = dxSrc;
+                return true;
+            }
+
+            // Compute the new height.
+            long dyNew = ((long)dySrc * minNew + (dxSrc >> 1)) / dxSrc;
+            Validation.Assert(dyNew >= minNew);
+            if (dyNew > int.MaxValue)
+                return false;
+            dy = (int)dyNew;
+            dx = minNew;
+        }
+
         return true;
     }
 

--- a/src/Test/Baseline/Code/CodeGen/ImageFuncs/ResizePixels.txt
+++ b/src/Test/Baseline/Code/CodeGen/ImageFuncs/ResizePixels.txt
@@ -97,6 +97,33 @@ Type: (Ten<u1>,Ten<u1>), Value: (
 )
 *** Ctx ping count: 0
 ###
+> With(t:MakeU1( 3,  2, 4), r:t->ResizePixels( 2), (t, r))
+With(t : MakeU1(3, 2, 4), r : t->ResizePixels(2), (t, r)) : (u1[*,*,*], u1[*,*,*]?)
+BndKind:Call, Type:(u1[*,*,*], u1[*,*,*]?), Bnd:(Call(∂.With([with:2] Call(∂.Tensor.From(Call(∂.ForEach([map:1] Call(∂.Range(24:i8):i8*), Call(∂.CastU1(Scope(1)):u1)):u1*), 3:i8, 2:i8, 4:i8):u1[*,*,*]), (Scope(2), Call(∂.ResizePixels(Scope(2), 2:i8):u1[*,*,*]?)):(u1[*,*,*], u1[*,*,*]?)):(u1[*,*,*], u1[*,*,*]?)))
+Func sig: (<ctx>:x) to (u1[*,*,*], u1[*,*,*]?)
+Type: (Ten<u1>,Ten<u1>), Value: (
+    Ten<u1>(3,2,4)<8,4,1>
+      [[[0, 1, 2, 3]
+        [4, 5, 6, 7]]
+
+       [[8, 9, A, B]
+        [C, D, E, F]]
+
+       [[10, 11, 12, 13]
+        [14, 15, 16, 17]]]
+  ,
+    Ten<u1>(3,2,4)<8,4,1>
+      [[[0, 1, 2, 3]
+        [4, 5, 6, 7]]
+
+       [[8, 9, A, B]
+        [C, D, E, F]]
+
+       [[10, 11, 12, 13]
+        [14, 15, 16, 17]]]
+)
+*** Ctx ping count: 0
+###
 > With(t:MakeU1(10, 20, 4), r:t->ResizePixels( 5), (t, r))
 With(t : MakeU1(10, 20, 4), r : t->ResizePixels(5), (t, r)) : (u1[*,*,*], u1[*,*,*]?)
 BndKind:Call, Type:(u1[*,*,*], u1[*,*,*]?), Bnd:(Call(∂.With([with:2] Call(∂.Tensor.From(Call(∂.ForEach([map:1] Call(∂.Range(800:i8):i8*), Call(∂.CastU1(Scope(1)):u1)):u1*), 10:i8, 20:i8, 4:i8):u1[*,*,*]), (Scope(2), Call(∂.ResizePixels(Scope(2), 5:i8):u1[*,*,*]?)):(u1[*,*,*], u1[*,*,*]?)):(u1[*,*,*], u1[*,*,*]?)))

--- a/src/Test/Baseline/Code/CodeGen/ImageFuncs/ResizePixels.txt
+++ b/src/Test/Baseline/Code/CodeGen/ImageFuncs/ResizePixels.txt
@@ -124,6 +124,31 @@ Type: (Ten<u1>,Ten<u1>), Value: (
 )
 *** Ctx ping count: 0
 ###
+> With(t:MakeU1( 2,  3, 4), r:t->ResizePixels( 2), (t, r))
+With(t : MakeU1(2, 3, 4), r : t->ResizePixels(2), (t, r)) : (u1[*,*,*], u1[*,*,*]?)
+BndKind:Call, Type:(u1[*,*,*], u1[*,*,*]?), Bnd:(Call(∂.With([with:2] Call(∂.Tensor.From(Call(∂.ForEach([map:1] Call(∂.Range(24:i8):i8*), Call(∂.CastU1(Scope(1)):u1)):u1*), 2:i8, 3:i8, 4:i8):u1[*,*,*]), (Scope(2), Call(∂.ResizePixels(Scope(2), 2:i8):u1[*,*,*]?)):(u1[*,*,*], u1[*,*,*]?)):(u1[*,*,*], u1[*,*,*]?)))
+Func sig: (<ctx>:x) to (u1[*,*,*], u1[*,*,*]?)
+Type: (Ten<u1>,Ten<u1>), Value: (
+    Ten<u1>(2,3,4)<12,4,1>
+      [[[0, 1, 2, 3]
+        [4, 5, 6, 7]
+        [8, 9, A, B]]
+
+       [[C, D, E, F]
+        [10, 11, 12, 13]
+        [14, 15, 16, 17]]]
+  ,
+    Ten<u1>(2,3,4)<12,4,1>
+      [[[0, 1, 2, 3]
+        [4, 5, 6, 7]
+        [8, 9, A, B]]
+
+       [[C, D, E, F]
+        [10, 11, 12, 13]
+        [14, 15, 16, 17]]]
+)
+*** Ctx ping count: 0
+###
 > With(t:MakeU1(10, 20, 4), r:t->ResizePixels( 5), (t, r))
 With(t : MakeU1(10, 20, 4), r : t->ResizePixels(5), (t, r)) : (u1[*,*,*], u1[*,*,*]?)
 BndKind:Call, Type:(u1[*,*,*], u1[*,*,*]?), Bnd:(Call(∂.With([with:2] Call(∂.Tensor.From(Call(∂.ForEach([map:1] Call(∂.Range(800:i8):i8*), Call(∂.CastU1(Scope(1)):u1)):u1*), 10:i8, 20:i8, 4:i8):u1[*,*,*]), (Scope(2), Call(∂.ResizePixels(Scope(2), 5:i8):u1[*,*,*]?)):(u1[*,*,*], u1[*,*,*]?)):(u1[*,*,*], u1[*,*,*]?)))

--- a/src/Test/Rexl.Code.Test/Scripts/CodeGen/ImageFuncs/ResizePixels.txt
+++ b/src/Test/Rexl.Code.Test/Scripts/CodeGen/ImageFuncs/ResizePixels.txt
@@ -5,6 +5,7 @@
 With(t:MakeU1( 1,  1, 4), r:t->ResizePixels( 2), (t, r))
 With(t:MakeU1( 3,  2, 4), r:t->ResizePixels( 6), (t, r))
 With(t:MakeU1( 3,  2, 4), r:t->ResizePixels( 2), (t, r))
+With(t:MakeU1( 2,  3, 4), r:t->ResizePixels( 2), (t, r))
 With(t:MakeU1(10, 20, 4), r:t->ResizePixels( 5), (t, r))
 With(t:MakeU1( 0, 20, 4), r:t->ResizePixels( 0), (t, r))
 With(t:MakeU1(10,  0, 4), r:t->ResizePixels(10), (t, r))

--- a/src/Test/Rexl.Code.Test/Scripts/CodeGen/ImageFuncs/ResizePixels.txt
+++ b/src/Test/Rexl.Code.Test/Scripts/CodeGen/ImageFuncs/ResizePixels.txt
@@ -4,6 +4,7 @@
 
 With(t:MakeU1( 1,  1, 4), r:t->ResizePixels( 2), (t, r))
 With(t:MakeU1( 3,  2, 4), r:t->ResizePixels( 6), (t, r))
+With(t:MakeU1( 3,  2, 4), r:t->ResizePixels( 2), (t, r))
 With(t:MakeU1(10, 20, 4), r:t->ResizePixels( 5), (t, r))
 With(t:MakeU1( 0, 20, 4), r:t->ResizePixels( 0), (t, r))
 With(t:MakeU1(10,  0, 4), r:t->ResizePixels(10), (t, r))


### PR DESCRIPTION
Fix `ResizePixels` when doing isotropic scaling and there is no change in the size.
Also tweak the `RexlKernel` to support registering rexl and pfx separately.