### PR TITLE
Add pipeline definition for Mac builds of RexlKernel

### DIFF
--- a/pipelines/build.yml
+++ b/pipelines/build.yml
@@ -1,6 +1,4 @@
 # Builds the Rexl projects and publish built artifacts to the internal artifact feed.
-# Note: If this pipeline is triggered for a Pull Request, no artifact is published, thus there will be nothing to deploy.
-# Note: The Debug and Release configurations will run in parallel.
 
 variables:
   PoolName: HostedAgent-Windows2022
@@ -55,5 +53,33 @@ jobs:
   parameters:
     buildConfig: Debug
     buildPlatform: $(BuildPlatform)
+    poolName: $(PoolName)
+    workFolder: $(WorkFolder)
+
+- template: ./build_mac.yml
+  parameters:
+    buildConfig: Release
+    buildPlatform: x64
+    poolName: $(PoolName)
+    workFolder: $(WorkFolder)
+
+- template: ./build_mac.yml
+  parameters:
+    buildConfig: Debug
+    buildPlatform: x64
+    poolName: $(PoolName)
+    workFolder: $(WorkFolder)
+
+- template: ./build_mac.yml
+  parameters:
+    buildConfig: Release
+    buildPlatform: arm64
+    poolName: $(PoolName)
+    workFolder: $(WorkFolder)
+
+- template: ./build_mac.yml
+  parameters:
+    buildConfig: Debug
+    buildPlatform: arm64
     poolName: $(PoolName)
     workFolder: $(WorkFolder)

--- a/pipelines/build_linux.yml
+++ b/pipelines/build_linux.yml
@@ -1,4 +1,4 @@
-# The linux core pipeline definition for Rexl build pipeline. 
+# Rexl build pipeline for linux.
 
 parameters:
 - name: buildConfig

--- a/pipelines/build_mac.yml
+++ b/pipelines/build_mac.yml
@@ -1,0 +1,45 @@
+# Rexl build pipeline for mac.
+
+parameters:
+- name: buildConfig
+  displayName: The build configuration
+  type: string
+  default: Release
+- name: buildPlatform
+  displayName: Build platform
+  type: string
+- name: poolName
+  displayName: Pool name
+  type: string
+- name: workFolder
+  displayName: Work folder
+  type: string
+
+jobs:
+- job: Build_Mac_${{ parameters.buildConfig }}_${{ parameters.buildPlatform }}
+  displayName: Build Rexl Mac - ${{ parameters.buildConfig }}
+  timeoutInMinutes: 20
+  pool:
+    name: ${{ parameters.poolName }}
+
+  steps:
+  - checkout: self
+    clean: true
+    lfs: true
+
+  - task: DotNetCoreCLI@2
+    displayName: Publish Self-Contained RexlKernel
+    inputs:
+      command: 'publish'
+      workingDirectory: $(Build.SourcesDirectory)/src
+      projects: '$(Build.SourcesDirectory)/src/Apps/Kernel/RexlKernel/RexlKernel.csproj'
+      arguments: '--sc -c ${{ parameters.buildConfig }} -p:Platform=${{ parameters.buildPlatform }} --runtime osx-${{ parameters.buildPlatform }} -o $(Build.ArtifactStagingDirectory)/Kernel'
+      publishWebProjects: false
+      zipAfterPublish: true
+      modifyOutputPath: true
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish RexlKernel artifact'
+    inputs:
+      PathToPublish: '$(Build.ArtifactStagingDirectory)/Kernel'
+      ArtifactName: 'Mac_${{ parameters.buildPlatform }}_${{ parameters.buildConfig }}_Kernel'

--- a/pipelines/build_win.yml
+++ b/pipelines/build_win.yml
@@ -1,4 +1,4 @@
-# The windows core pipeline definition for Rexl build pipeline. 
+# Rexl build pipeline for windows.
 # Publishes the built artifacts to the artifact store
 # if the `publishArtifacts` parameter is set to `true`.
 


### PR DESCRIPTION
This change adds MacOS builds of `RexlKernel` to the pipeline.