### PR TITLE
feat: Porting PadLeft and PadRight from C#

### DIFF
--- a/src/Core/Rexl.Bind/Operations/BuiltinFunctions.cs
+++ b/src/Core/Rexl.Bind/Operations/BuiltinFunctions.cs
@@ -378,6 +378,8 @@ public class BuiltinFunctions : OperationRegistry
         AddOne(TextTrimFunc.TrimStart, new Sig(S.AboutTrimStart, A.Create(S.ArgSource, S.AboutTrimStart_Source)));
         AddOne(TextTrimFunc.TrimEnd, new Sig(S.AboutTrimEnd, A.Create(S.ArgSource, S.AboutTrimEnd_Source)));
 
+        AddOne(TextPadLeftFunc.Instance, new Sig(S.AboutPadLeft, A.Create(S.ArgSource, S.AboutPadLeft_Source)));
+
         AddOne(TextReplaceFunc.Instance, new Sig(S.AboutTextReplace,
             A.Create(S.ArgSource, S.AboutTextReplace_Source),
             A.Create(S.TextReplace_Remove, S.AboutTextReplace_Remove),

--- a/src/Core/Rexl.Bind/Operations/BuiltinFunctions.cs
+++ b/src/Core/Rexl.Bind/Operations/BuiltinFunctions.cs
@@ -378,7 +378,8 @@ public class BuiltinFunctions : OperationRegistry
         AddOne(TextTrimFunc.TrimStart, new Sig(S.AboutTrimStart, A.Create(S.ArgSource, S.AboutTrimStart_Source)));
         AddOne(TextTrimFunc.TrimEnd, new Sig(S.AboutTrimEnd, A.Create(S.ArgSource, S.AboutTrimEnd_Source)));
 
-        AddOne(TextPadLeftFunc.Instance, new Sig(S.AboutPadLeft, A.Create(S.ArgSource, S.AboutPadLeft_Source)));
+        AddOne(TextPadFunc.Left, new Sig(S.AboutPadLeft, A.Create(S.ArgSource, S.AboutPad_Source)));
+        AddOne(TextPadFunc.Right, new Sig(S.AboutPadRight, A.Create(S.ArgSource, S.AboutPad_Source)));
 
         AddOne(TextReplaceFunc.Instance, new Sig(S.AboutTextReplace,
             A.Create(S.ArgSource, S.AboutTextReplace_Source),

--- a/src/Core/Rexl.Bind/Operations/Funcs/Text.cs
+++ b/src/Core/Rexl.Bind/Operations/Funcs/Text.cs
@@ -679,43 +679,6 @@ public sealed partial class TextTrimFunc : TextFuncOne
     }
 }
 
-public sealed partial class TextPadLeftFunc: TextFuncOne
-{
-    public static readonly TextPadLeftFunc Instance = new TextPadLeftFunc();
-
-    private TextPadLeftFunc()
-        : base(new DName("PadLeft"), BindUtil.TextNs, 1, 2)
-    {
-    }
-
-    protected override ArgTraits GetArgTraitsCore(int carg)
-    {
-        Validation.Assert(SupportsArity(carg));
-        return ArgTraitsSimple.Create(this, eager: true, carg);
-    }
-
-    protected override bool CertifyCore(BndCallNode call, ref bool full)
-    {
-        if (call.Type != DType.Text)
-            return false;
-        // var args = call.Args;
-        // if (args[0].Type != DType.I8Req)
-        //     return false;
-        // if (args[1].Type != DType.Text)
-        //     return false;
-        return true;
-    }
-
-    public static string Exec(string src, int padding_len)
-    {
-        if (string.IsNullOrEmpty(src))
-            return src;
-        if (padding_len == 0)
-            return src;
-        return src.PadLeft(padding_len);
-    }
-}
-
 public sealed partial class TextReplaceFunc : RexlOper
 {
     public static readonly TextReplaceFunc Instance = new TextReplaceFunc();
@@ -793,5 +756,44 @@ public sealed partial class TextReplaceFunc : RexlOper
         if (string.IsNullOrEmpty(remove))
             return src;
         return src.Replace(remove, insert);
+    }
+}
+
+public sealed partial class TextPadLeftFunc: RexlOper
+{
+    public static readonly TextPadLeftFunc Instance = new TextPadLeftFunc();
+
+    private TextPadLeftFunc()
+        : base(isFunc: true, new DName("PadLeft"), BindUtil.TextNs, 1, 2)
+    {
+    }
+
+    public Func<string, string> Map { get; }
+
+    protected override ArgTraits GetArgTraitsCore(int carg)
+    {
+        Validation.Assert(SupportsArity(carg));
+        return ArgTraitsSimple.Create(this, eager: true, carg);
+    }
+
+    protected override bool CertifyCore(BndCallNode call, ref bool full)
+    {
+        if (call.Type != DType.Text)
+            return false;
+        // var args = call.Args;
+        // if (args[0].Type != DType.I8Req)
+        //     return false;
+        // if (args[1].Type != DType.Text)
+        //     return false;
+        return true;
+    }
+
+    public static string Exec(string src, int padding_len)
+    {
+        if (string.IsNullOrEmpty(src))
+            return src;
+        if (padding_len == 0)
+            return src;
+        return src.PadLeft(padding_len);
     }
 }

--- a/src/Core/Rexl.Bind/Operations/Funcs/Text.cs
+++ b/src/Core/Rexl.Bind/Operations/Funcs/Text.cs
@@ -679,56 +679,40 @@ public sealed partial class TextTrimFunc : TextFuncOne
     }
 }
 
-public sealed partial class TextPadLeftFunc: RexlOper
+public sealed partial class TextPadLeftFunc: TextFuncOne
 {
     public static readonly TextPadLeftFunc Instance = new TextPadLeftFunc();
 
     private TextPadLeftFunc()
-        : base(isFunc: true, new DName("PadLeft"), BindUtil.TextNs, 1, 2)
+        : base(new DName("PadLeft"), BindUtil.TextNs, 1, 2)
     {
     }
 
     protected override ArgTraits GetArgTraitsCore(int carg)
     {
-        Validation.BugCheckParam(SupportsArity(carg), nameof(carg));
-        var maskAll = BitSet.GetMask(carg);
-        var maskOpt = maskAll.ClearBit(0);
-        return ArgTraitsLifting.Create(this, carg, maskLiftSeq: maskAll, maskLiftTen: maskAll);
-    }
-
-
-
-    protected override BoundNode ReduceCore(IReducer reducer, BndCallNode call)
-    {
-        Validation.AssertValue(reducer);
-        Validation.Assert(IsValidCall(call));
-
-        var args = call.Args;
-        if (args[0].TryGetString(out var str))
-            return BndIntNode.CreateI8(Util.Size(str));
-
-        return call;
+        Validation.Assert(SupportsArity(carg));
+        return ArgTraitsSimple.Create(this, eager: true, carg);
     }
 
     protected override bool CertifyCore(BndCallNode call, ref bool full)
     {
         if (call.Type != DType.Text)
             return false;
-        var args = call.Args;
-        if (args[0].Type != DType.I8Req)
-            return false;
-        if (args[1].Type != DType.Text)
-            return false;
+        // var args = call.Args;
+        // if (args[0].Type != DType.I8Req)
+        //     return false;
+        // if (args[1].Type != DType.Text)
+        //     return false;
         return true;
     }
 
-    public static string Exec(string src, int padding_len, char padding_char = ' ')
+    public static string Exec(string src, int padding_len)
     {
         if (string.IsNullOrEmpty(src))
             return src;
         if (padding_len == 0)
             return src;
-        return src.PadLeft(padding_len, padding_char);
+        return src.PadLeft(padding_len);
     }
 }
 

--- a/src/Core/Rexl.Bind/Strings/RexlStrings.cs
+++ b/src/Core/Rexl.Bind/Strings/RexlStrings.cs
@@ -342,14 +342,16 @@ static partial class RexlStrings
     public static readonly StringId AboutUpper = new(nameof(AboutUpper), "Converts text to uppercase.");
     public static readonly StringId AboutUpper_Source = new(nameof(AboutUpper_Source), "The text to convert to uppercase.");
 
+    public static readonly StringId AboutPadLeft = new(nameof(AboutPadLeft), "Adds characters to the left of a string.");
+    public static readonly StringId AboutPadRight = new(nameof(AboutPadRight), "Adds characters to the right of a string.");
+    public static readonly StringId AboutPad_Source = new(nameof(AboutPad_Source), "The text to add padding to.");
+
     public static readonly StringId AboutStartsWith = new(nameof(AboutStartsWith), "Tests whether the beginning of the source text matches the lookup text.");
     public static readonly StringId AboutStartsWith_Source = new(nameof(AboutStartsWith_Source), "The text to look in.");
     public static readonly StringId AboutStartsWith_LookUp = new(nameof(AboutStartsWith_LookUp), "The text to look for.");
 
     public static readonly StringId AboutEndsWith = new(nameof(AboutEndsWith), "Tests whether the end of the source text matches the lookup text.");
 
-    public static readonly StringId AboutPadLeft = new(nameof(AboutPadLeft), "Returns a new string with the provided number of spaces/specified characters added to the left.");
-    public static readonly StringId AboutPadLeft_Source = new(nameof(AboutPadLeft), "The text to convert to lowercase.");
     public static readonly StringId AboutStrLen = new(nameof(AboutStrLen), "Returns the number of characters in the text value.");
     public static readonly StringId AboutStrLen_Source = new(nameof(AboutStrLen_Source), "The text in which to count the characters.");
 

--- a/src/Core/Rexl.Bind/Strings/RexlStrings.cs
+++ b/src/Core/Rexl.Bind/Strings/RexlStrings.cs
@@ -348,6 +348,8 @@ static partial class RexlStrings
 
     public static readonly StringId AboutEndsWith = new(nameof(AboutEndsWith), "Tests whether the end of the source text matches the lookup text.");
 
+    public static readonly StringId AboutPadLeft = new(nameof(AboutPadLeft), "Returns a new string with the provided number of spaces/specified characters added to the left.");
+    public static readonly StringId AboutPadLeft_Source = new(nameof(AboutPadLeft), "The text to convert to lowercase.");
     public static readonly StringId AboutStrLen = new(nameof(AboutStrLen), "Returns the number of characters in the text value.");
     public static readonly StringId AboutStrLen_Source = new(nameof(AboutStrLen_Source), "The text in which to count the characters.");
 

--- a/src/Core/Rexl.Bind/Strings/RexlStrings.tt
+++ b/src/Core/Rexl.Bind/Strings/RexlStrings.tt
@@ -336,6 +336,9 @@ AboutLower_Source = "The text to convert to lowercase."
 AboutUpper = "Converts text to uppercase."
 AboutUpper_Source = "The text to convert to uppercase."
 
+AboutPadLeft = "Adds characters to the left of a string."
+AboutPadLeft_Source = "The text to add padding to."
+
 AboutStartsWith = "Tests whether the beginning of the source text matches the lookup text."
 AboutStartsWith_Source = "The text to look in."
 AboutStartsWith_LookUp = "The text to look for."

--- a/src/Core/Rexl.Bind/Strings/RexlStrings.tt
+++ b/src/Core/Rexl.Bind/Strings/RexlStrings.tt
@@ -337,7 +337,8 @@ AboutUpper = "Converts text to uppercase."
 AboutUpper_Source = "The text to convert to uppercase."
 
 AboutPadLeft = "Adds characters to the left of a string."
-AboutPadLeft_Source = "The text to add padding to."
+AboutPadRight = "Adds characters to the right of a string."
+AboutPad_Source = "The text to add padding to."
 
 AboutStartsWith = "Tests whether the beginning of the source text matches the lookup text."
 AboutStartsWith_Source = "The text to look in."

--- a/src/Core/Rexl.Code/Operations/BuiltinGenerators.cs
+++ b/src/Core/Rexl.Code/Operations/BuiltinGenerators.cs
@@ -59,7 +59,7 @@ public sealed class BuiltinGenerators : GeneratorRegistry
         Add(TextPartGen.Instance);
         Add(TextTrimGen.Instance);
         Add(TextReplaceGen.Instance);
-        Add(TextPadLeftGen.Instance);
+        Add(TextPadGen.Instance);
 
         Add(typeof(SumFunc), SumBaseGen.Instance);
         Add(typeof(MeanFunc), SumBaseGen.Instance);

--- a/src/Core/Rexl.Code/Operations/BuiltinGenerators.cs
+++ b/src/Core/Rexl.Code/Operations/BuiltinGenerators.cs
@@ -59,6 +59,7 @@ public sealed class BuiltinGenerators : GeneratorRegistry
         Add(TextPartGen.Instance);
         Add(TextTrimGen.Instance);
         Add(TextReplaceGen.Instance);
+        Add(TextPadLeftGen.Instance);
 
         Add(typeof(SumFunc), SumBaseGen.Instance);
         Add(typeof(MeanFunc), SumBaseGen.Instance);

--- a/src/Core/Rexl.Code/Operations/Funcs/Text.cs
+++ b/src/Core/Rexl.Code/Operations/Funcs/Text.cs
@@ -293,3 +293,26 @@ public sealed class TextReplaceGen : GetMethGen<TextReplaceFunc>
         return true;
     }
 }
+
+public sealed class TextPadLeftGen : GetMethGen<TextPadLeftFunc>
+{
+    public static readonly TextPadLeftGen Instance = new TextPadLeftGen();
+
+    //private readonly MethodInfo _meth;
+
+    private TextPadLeftGen()
+    {
+        //_meth = new Func<string, int>(TextPadLeftFunc.Exec).Method;
+    }
+
+
+    protected override bool TryGetMeth(ICodeGen codeGen, BndCallNode call, out MethodInfo meth)
+    {
+        Validation.AssertValue(codeGen);
+        Validation.Assert(IsValidCall(call, true));
+
+        var fn = GetOper(call);
+        meth = fn.Map.Method;
+        return true;
+    }
+}

--- a/src/Core/Rexl.Code/Operations/Funcs/Text.cs
+++ b/src/Core/Rexl.Code/Operations/Funcs/Text.cs
@@ -294,17 +294,18 @@ public sealed class TextReplaceGen : GetMethGen<TextReplaceFunc>
     }
 }
 
-public sealed class TextPadLeftGen : GetMethGen<TextPadLeftFunc>
+public sealed class TextPadGen : GetMethGen<TextPadFunc>
 {
-    public static readonly TextPadLeftGen Instance = new TextPadLeftGen();
+    public static readonly TextPadGen Instance = new TextPadGen();
 
-    //private readonly MethodInfo _meth;
+    private readonly MethodInfo _methLeft;
+    private readonly MethodInfo _methRight;
 
-    private TextPadLeftGen()
+    private TextPadGen()
     {
-        //_meth = new Func<string, int>(TextPadLeftFunc.Exec).Method;
+        _methLeft = new Func<string, long, string>(TextPadFunc.ExecLeft).Method;
+        _methRight = new Func<string, long, string>(TextPadFunc.ExecRight).Method;
     }
-
 
     protected override bool TryGetMeth(ICodeGen codeGen, BndCallNode call, out MethodInfo meth)
     {
@@ -312,7 +313,7 @@ public sealed class TextPadLeftGen : GetMethGen<TextPadLeftFunc>
         Validation.Assert(IsValidCall(call, true));
 
         var fn = GetOper(call);
-        meth = fn.Map.Method;
+        meth = fn.IsLeft ? _methLeft : _methRight;
         return true;
     }
 }

--- a/src/Test/Rexl.Bind.Test/Scripts/Binder/Functions/String.txt
+++ b/src/Test/Rexl.Bind.Test/Scripts/Binder/Functions/String.txt
@@ -238,6 +238,14 @@ Text.Replace("ABC", "X", s)
 Text.Replace("ABC", "B", "X")
 Text.Replace("ABACDAE", "A", "!!")
 
+Text.PadLeft(null, 0)
+Text.PadLeft("hello", -1)
+Text.PadLeft("hello", 10)
+
+Text.PadRight(null, 0)
+Text.PadRight("hello", -1)
+Text.PadRight("          hello", 10)
+
 // Lifting.
 :: {g:g*, o:o*, s:s*, b:b*, qb:b?*, d:d*, n:n*, qn:n?*, r8:r8*, qr8:r8?*, r4:r4*, qr4:r4?*, i:i*, qi:i?*, i8:i8*, qi8:i8?*, i4:i4*, qi4:i4?*, i2:i2*, qi2:i2?*, i1:i1*, qi1:i1?*, u8:u8*, qu8:u8?*, u4:u4*, qu4:u4?*, u2:u2*, qu2:u2?*, u1:u1*, qu1:u1?*}
 
@@ -360,3 +368,11 @@ Text.Replace("ABC", s, s)
 Text.Replace(s, s, s)
 
 Text.Replace(s, "", s)
+
+Text.PadLeft(null, 0)
+Text.PadLeft("hello", -1)
+Text.PadLeft("hello", 10)
+
+Text.PadRight(null, 0)
+Text.PadRight("hello", -1)
+Text.PadRight("          hello", 10)

--- a/src/Test/Rexl.Code.Test/Scripts/CodeGen/Functions/String.txt
+++ b/src/Test/Rexl.Code.Test/Scripts/CodeGen/Functions/String.txt
@@ -71,3 +71,14 @@ Text.TrimEnd(Wrap(Null(""))) | With(_, {S: it, L: Text.Len(it)})
 Text.Replace(N, "A", "B")
 Text.Replace("A", N, "B")
 Text.Replace("ABC", Wrap("B"), N)
+
+Text.PadLeft(null, 0)
+Text.PadLeft("hello", -1)
+Text.PadLeft("hello", 10)
+Text.PadLeft(Wrap("hello"), 10)
+
+Text.PadRight(null, 0)
+Text.PadRight("hello", -1)
+Text.PadRight("     hello", 5)
+Text.PadRight(Wrap("          hello"), 10)
+


### PR DESCRIPTION
This PR adds support for calling the single argument version of PadLeft and PadRight to the Text functions. These functions take as arguments the strings they're operating on and the number of spaces to add as padding. Also have some basic tests, feedback on those is very much appreciated as I may be missing some things there.

C# docs for functions this PR includes:
https://learn.microsoft.com/en-us/dotnet/api/system.string.padleft?view=net-8.0#system-string-padleft(system-int32)
https://learn.microsoft.com/en-us/dotnet/api/system.string.padright?view=net-8.0#system-string-padright(system-int32)